### PR TITLE
Add lens combinators and collection action helpers

### DIFF
--- a/core/src/main/scala/conduit/ActionHandlerCollections.scala
+++ b/core/src/main/scala/conduit/ActionHandlerCollections.scala
@@ -1,0 +1,154 @@
+package conduit
+
+import zio.*
+
+/** Collection-aware action helpers. Each function takes an ambient `Lens[M, C]` focused on a collection-shaped slice of
+  * the model and returns an [[ActionFunction]] that updates that focus.
+  *
+  * Pattern:
+  * {{{
+  *   given Lens[Model, List[Item]] = Optics[Model](_.items)
+  *   val handler = handle(Optics[Model](_.items)):
+  *     case AddItem(x) => appendToList(x)
+  *     case Drop(p)    => filterList(p)
+  * }}}
+  *
+  * No-op cases (out-of-range indexes, missing keys, predicate failures on `whenCondition` / `safeTransform`) return
+  * [[ActionResult.clean]] so the conduit knows no state change occurred.
+  */
+object ActionHandlerCollections:
+
+  // ── Option ────────────────────────────────────────────────────────────────
+
+  def updateOption[M, V, E](f: V => V)(using lens: Lens[M, Option[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).map(f))))
+
+  def setSome[M, V, E](value: V)(using lens: Lens[M, Option[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, Some(value))))
+
+  def setNone[M, V, E](using lens: Lens[M, Option[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, None)))
+
+  /** Drop the focused Option's value if it doesn't satisfy `predicate`. */
+  def filterOptionAction[M, V, E](predicate: V => Boolean)(using lens: Lens[M, Option[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).filter(predicate))))
+
+  /** If the focus is None, write `default`; otherwise leave the value alone. */
+  def orElseOption[M, V, E](default: Option[V])(using lens: Lens[M, Option[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).orElse(default))))
+
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  def updateList[M, V, E](f: V => V)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).map(f))))
+
+  def filterListAction[M, V, E](predicate: V => Boolean)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).filter(predicate))))
+
+  def appendToList[M, V, E](items: V*)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m) ++ items)))
+
+  def prependToList[M, V, E](items: V*)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, items.toList ++ lens.get(m))))
+
+  def removeFromList[M, V, E](item: V)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).filterNot(_ == item))))
+
+  /** Update the element at `index` to `value`. Out-of-range or negative indexes leave the model untouched (returns
+    * clean).
+    */
+  def updateAtListIndex[M, V, E](index: Int, value: V)(using lens: Lens[M, List[V]]): ActionFunction[M, E] =
+    m =>
+      val xs = lens.get(m)
+      if index >= 0 && index < xs.length then ZIO.succeed(ActionResult(lens.set(m, xs.updated(index, value))))
+      else ZIO.succeed(ActionResult.clean(m))
+
+  // ── Vector ────────────────────────────────────────────────────────────────
+
+  def updateVector[M, V, E](f: V => V)(using lens: Lens[M, Vector[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).map(f))))
+
+  def filterVectorAction[M, V, E](predicate: V => Boolean)(using lens: Lens[M, Vector[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).filter(predicate))))
+
+  def appendToVector[M, V, E](items: V*)(using lens: Lens[M, Vector[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m) ++ items)))
+
+  def prependToVector[M, V, E](items: V*)(using lens: Lens[M, Vector[V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, items.toVector ++ lens.get(m))))
+
+  /** Update the element at `index`. Out-of-range or negative indexes leave the model untouched (returns clean). */
+  def updateAtVectorIndex[M, V, E](index: Int, value: V)(using lens: Lens[M, Vector[V]]): ActionFunction[M, E] =
+    m =>
+      val v = lens.get(m)
+      if index >= 0 && index < v.length then ZIO.succeed(ActionResult(lens.set(m, v.updated(index, value))))
+      else ZIO.succeed(ActionResult.clean(m))
+
+  // ── Map ───────────────────────────────────────────────────────────────────
+
+  def updateMapValues[M, K, V, E](f: V => V)(using lens: Lens[M, Map[K, V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).view.mapValues(f).toMap)))
+
+  def filterMapValues[M, K, V, E](predicate: V => Boolean)(using lens: Lens[M, Map[K, V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m).filter((_, v) => predicate(v)))))
+
+  def putInMap[M, K, V, E](key: K, value: V)(using lens: Lens[M, Map[K, V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m) + (key -> value))))
+
+  def removeFromMap[M, K, V, E](key: K)(using lens: Lens[M, Map[K, V]]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, lens.get(m) - key)))
+
+  /** Apply `f` to the value at `key`. If the key is absent, the model is untouched (returns clean). */
+  def updateAtMapKey[M, K, V, E](key: K, f: V => V)(using lens: Lens[M, Map[K, V]]): ActionFunction[M, E] =
+    m =>
+      val mp = lens.get(m)
+      mp.get(key) match
+        case Some(v) => ZIO.succeed(ActionResult(lens.set(m, mp + (key -> f(v)))))
+        case None    => ZIO.succeed(ActionResult.clean(m))
+
+  // ── Generic context-function patterns ─────────────────────────────────────
+
+  /** Apply `op` only when the focus satisfies `predicate`. Otherwise no-op (clean). */
+  def whenCondition[M, V, E](predicate: V => Boolean)(op: V => V)(using lens: Lens[M, V]): ActionFunction[M, E] =
+    m =>
+      val v = lens.get(m)
+      if predicate(v) then ZIO.succeed(ActionResult(lens.set(m, op(v))))
+      else ZIO.succeed(ActionResult.clean(m))
+
+  /** Apply `transform`; on `Left` the model is untouched (returns clean). The error value is discarded — use a real
+    * typed error in your handler if you need to surface it.
+    */
+  def safeTransform[M, V, X, E](transform: V => Either[X, V])(using lens: Lens[M, V]): ActionFunction[M, E] =
+    m =>
+      transform(lens.get(m)) match
+        case Right(v) => ZIO.succeed(ActionResult(lens.set(m, v)))
+        case Left(_)  => ZIO.succeed(ActionResult.clean(m))
+
+  /** Apply each operation in sequence to the focused value. Empty list is a write-through identity (still marks dirty
+    * because it ran a set). For a true no-op use [[whenCondition]].
+    */
+  def sequenceOps[M, V, E](ops: List[V => V])(using lens: Lens[M, V]): ActionFunction[M, E] =
+    m => ZIO.succeed(ActionResult(lens.set(m, ops.foldLeft(lens.get(m))((a, op) => op(a)))))
+
+  /** Find the first element matching `finder` in the focused list and replace it with `updater(found)`. If no match,
+    * no-op (clean). All occurrences of the matched value are replaced.
+    */
+  def findAndUpdate[M, V, E](finder: List[V] => Option[V])(updater: V => V)(using
+      lens: Lens[M, List[V]]
+  ): ActionFunction[M, E] =
+    m =>
+      val xs = lens.get(m)
+      finder(xs) match
+        case Some(found) => ZIO.succeed(ActionResult(lens.set(m, xs.map(v => if v == found then updater(v) else v))))
+        case None        => ZIO.succeed(ActionResult.clean(m))
+
+  /** Apply `op` to the focused list iff `cond(list)` holds. Otherwise no-op (clean). */
+  def batchOperation[M, V, E](cond: List[V] => Boolean)(op: List[V] => List[V])(using
+      lens: Lens[M, List[V]]
+  ): ActionFunction[M, E] =
+    m =>
+      val xs = lens.get(m)
+      if cond(xs) then ZIO.succeed(ActionResult(lens.set(m, op(xs))))
+      else ZIO.succeed(ActionResult.clean(m))
+
+end ActionHandlerCollections

--- a/core/src/main/scala/conduit/AdvancedContextFunctions.scala
+++ b/core/src/main/scala/conduit/AdvancedContextFunctions.scala
@@ -1,0 +1,94 @@
+package conduit
+
+/** Lens-derivation combinators that compose with an ambient `Lens[M, V]` (Scala 3 context functions). They let you
+  * derive new lenses without threading the base through every call.
+  *
+  * ## Deriving a sub-lens To derive a `Lens[M, W]` from an `Lens[M, V]` and a path `V => W`, use the existing
+  * `Lens.apply`:
+  * {{{
+  *   val userLens: Lens[Model, User] = Optics[Model](_.user)
+  *   val nameLens: Lens[Model, String] = userLens(_.name)
+  * }}}
+  * That already does what a context-function `focus` would do, with cleaner inference.
+  *
+  * ## What this module adds
+  *   - [[when]] — Option view that only reads when a predicate holds.
+  *   - [[validated]] — Either view that reads via a partial transform.
+  *   - [[multi]] — pair two independent lenses into one.
+  *   - [[navigate]] — Option-with-default view, lossy on the default branch.
+  *   - [[For]] — ergonomic handler builder for a model with many small handlers.
+  */
+object AdvancedContextFunctions:
+
+  /** Lens that exposes the ambient value as Some(_) only when it satisfies `predicate`; None otherwise. Setting
+    * Some(invalid) is a no-op (preserves on-success lens laws).
+    */
+  def when[M, V](predicate: V => Boolean): Lens[M, V] ?=> Lens[M, Option[V]] = lens ?=>
+    new Lens[M, Option[V]]:
+      def get(m: M): Option[V] =
+        val v = lens.get(m)
+        if predicate(v) then Some(v) else None
+      def set(m: M, optV: Option[V]): M =
+        optV match
+          case Some(v) if predicate(v) => lens.set(m, v)
+          case _                       => m
+
+  /** Lens that exposes a validated view of the ambient value via `to`, with `from` as the inverse on the success
+    * branch. `set Left(_)` is a no-op (no inverse for failure).
+    */
+  def validated[M, V, W, E](to: V => Either[E, W], from: W => V): Lens[M, V] ?=> Lens[M, Either[E, W]] = lens ?=>
+    new Lens[M, Either[E, W]]:
+      def get(m: M): Either[E, W] = to(lens.get(m))
+      def set(m: M, either: Either[E, W]): M =
+        either match
+          case Right(w) => lens.set(m, from(w))
+          case Left(_)  => m
+
+  /** Combine two independent lenses on the same model into one focused on a tuple. Lens laws hold iff the two lenses
+    * don't overlap (no field is reachable through both).
+    */
+  def multi[M, V1, V2](lens1: Lens[M, V1], lens2: Lens[M, V2]): Lens[M, (V1, V2)] =
+    new Lens[M, (V1, V2)]:
+      def get(m: M): (V1, V2) = (lens1.get(m), lens2.get(m))
+      def set(m: M, t: (V1, V2)): M =
+        val (v1, v2) = t
+        lens2.set(lens1.set(m, v1), v2)
+
+  /** Safe-navigation lens. `path` extracts an inner value (or returns `defaultValue` if absent); `inverse` writes a new
+    * W back into V. Lawfulness depends on the caller's `inverse`:
+    *   - set-get holds when `path(inverse(v, w)) == Some(w)`
+    *   - get-set is intrinsically lossy on the default branch: you can't tell None from Some(default).
+    */
+  def navigate[M, V, W](
+      path: V => Option[W],
+      defaultValue: W,
+      inverse: (V, W) => V,
+  ): Lens[M, V] ?=> Lens[M, W] = baseLens ?=>
+    new Lens[M, W]:
+      def get(m: M): W       = path(baseLens.get(m)).getOrElse(defaultValue)
+      def set(m: M, w: W): M = baseLens.set(m, inverse(baseLens.get(m), w))
+
+  /** Builder for a family of handlers over the same model M, all with the same error type E. Saves repetition when a
+    * module defines several small handlers:
+    *
+    * {{{
+    *   val For = AdvancedContextFunctions.For[Model, MyErr]
+    *   val nameH  = For.field(_.user.name)  { case Rename(n) => updated(n) }
+    *   val itemsH = For.field(_.items)      { case Add(x)    => update(_ :+ x) }
+    * }}}
+    *
+    * Equivalent to `handle(Optics[Model](path))(body)` — same lens, same handler, just less typing.
+    */
+  inline def For[M <: Product, E](using o: Optics[M]): ForBuilder[M, E] = new ForBuilder[M, E]
+
+  final class ForBuilder[M <: Product, E](using o: Optics[M]):
+    /** Build a handler focused on the field at `path`. */
+    inline def field[V](inline path: M => V)(body: Lens[M, V] ?=> ActionSelector[M, E]): ActionHandler[M, V, E] =
+      handle[M, V, E](o(path))(body)
+
+    /** Build a handler focused on the whole model. */
+    def model(body: Lens[M, M] ?=> ActionSelector[M, E]): ActionHandler[M, M, E] =
+      handle[M, M, E](o)(body)
+  end ForBuilder
+
+end AdvancedContextFunctions

--- a/core/src/main/scala/conduit/BidirectionalLens.scala
+++ b/core/src/main/scala/conduit/BidirectionalLens.scala
@@ -1,0 +1,117 @@
+package conduit
+
+/** Bidirectional lens transformations that require explicit inverse functions. These provide more practical
+  * map/flatMap-like operations for collections while maintaining lens laws.
+  */
+object BidirectionalLens:
+
+  /** Isomorphism between two types - bidirectional transformation. */
+  case class Iso[A, B](to: A => B, from: B => A):
+    def reverse: Iso[B, A] = Iso(from, to)
+
+  extension [M, V](lens: Lens[M, V])
+    /** Transform a lens using an isomorphism. */
+    def imap[W](iso: Iso[V, W]): Lens[M, W] =
+      new Lens[M, W]:
+        def get(m: M): W       = iso.to(lens.get(m))
+        def set(m: M, w: W): M = lens.set(m, iso.from(w))
+
+    /** Transform a lens with explicit to/from functions. */
+    def xmap[W](to: V => W, from: W => V): Lens[M, W] =
+      imap(Iso(to, from))
+  end extension
+
+  /** Collection-specific bidirectional transformations. */
+  object Collections:
+
+    /** Isomorphisms for common collection conversions. */
+    object Isos:
+      def listToVector[A]: Iso[List[A], Vector[A]] =
+        Iso(_.toVector, _.toList)
+
+      def vectorToList[A]: Iso[Vector[A], List[A]] =
+        listToVector.reverse
+
+      /** Set ↔ List. Note: Set→List→Set is lossy (drops order/duplicates). */
+      def setToList[A]: Iso[Set[A], List[A]] =
+        Iso(_.toList, _.toSet)
+
+      def mapToList[K, V]: Iso[Map[K, V], List[(K, V)]] =
+        Iso(_.toList, _.toMap)
+
+      /** Option ↔ List (one-element). None ↔ Nil; multi-element lists collapse to head. */
+      def optionToList[A]: Iso[Option[A], List[A]] =
+        Iso(_.toList, _.headOption)
+    end Isos
+
+    extension [M, V](lens: Lens[M, List[V]])
+      def mapListBi[W](to: V => W, from: W => V): Lens[M, List[W]] =
+        lens.xmap(_.map(to), _.map(from))
+
+      def asVector: Lens[M, Vector[V]] =
+        lens.imap(Isos.listToVector)
+    end extension
+
+    extension [M, V](lens: Lens[M, Option[V]])
+      def mapOptionBi[W](to: V => W, from: W => V): Lens[M, Option[W]] =
+        lens.xmap(_.map(to), _.map(from))
+
+      def asList: Lens[M, List[V]] =
+        lens.imap(Isos.optionToList)
+
+      /** Treat None as `default`. Setting `default` collapses to None. */
+      def withDefault(default: V): Lens[M, V] =
+        new Lens[M, V]:
+          def get(m: M): V = lens.get(m).getOrElse(default)
+          def set(m: M, v: V): M =
+            if v == default then lens.set(m, None)
+            else lens.set(m, Some(v))
+    end extension
+
+    extension [M, K, V](lens: Lens[M, Map[K, V]])
+      def mapValuesBi[W](to: V => W, from: W => V): Lens[M, Map[K, W]] =
+        lens.xmap(_.view.mapValues(to).toMap, _.view.mapValues(from).toMap)
+
+      @annotation.targetName("mapAsList")
+      def asList: Lens[M, List[(K, V)]] =
+        lens.imap(Isos.mapToList)
+
+      /** Focus the keyset. Setting drops entries whose keys aren't in the new set; never invents values. */
+      def keySet: Lens[M, Set[K]] =
+        new Lens[M, Set[K]]:
+          def get(m: M): Set[K] = lens.get(m).keySet
+          def set(m: M, keys: Set[K]): M =
+            val currentMap = lens.get(m)
+            lens.set(m, currentMap.filter((k, _) => keys.contains(k)))
+    end extension
+  end Collections
+
+  /** Validation and filtering with lens laws. */
+  object Validation:
+
+    /** Lens that exposes the focused value only when it satisfies `predicate`; otherwise None. Setting Some(v) where
+      * !predicate(v) is a no-op (preserves lens-set-set law on the success branch).
+      */
+    def validated[M, V](
+        lens: Lens[M, V]
+    )(predicate: V => Boolean): Lens[M, Option[V]] =
+      new Lens[M, Option[V]]:
+        def get(m: M): Option[V] =
+          val value = lens.get(m)
+          if predicate(value) then Some(value) else None
+        def set(m: M, optV: Option[V]): M =
+          optV match
+            case Some(v) if predicate(v) => lens.set(m, v)
+            case _                       => m
+
+    /** Lens that exposes only elements satisfying `predicate`; setting filters incoming list as well. */
+    def filteredList[M, V](
+        lens: Lens[M, List[V]]
+    )(predicate: V => Boolean): Lens[M, List[V]] =
+      new Lens[M, List[V]]:
+        def get(m: M): List[V] = lens.get(m).filter(predicate)
+        def set(m: M, list: List[V]): M =
+          lens.set(m, list.filter(predicate))
+  end Validation
+
+end BidirectionalLens

--- a/core/src/main/scala/conduit/CollectionLens.scala
+++ b/core/src/main/scala/conduit/CollectionLens.scala
@@ -1,0 +1,146 @@
+package conduit
+
+/** Collection-aware lens extensions: focus on elements, keys, and slices of `Option`, `List`, `Map`, `Vector`.
+  *
+  * All lenses here obey lens laws — `set` is a real write-back. For read-only transformations whose forward function
+  * isn't invertible (e.g. `map`, `flatMap` over a collection), use [[BidirectionalLens]] which requires the caller to
+  * supply an inverse.
+  */
+object CollectionLens:
+
+  extension [M, V](lens: Lens[M, Option[V]])
+    /** Filter: get returns Some only when the value satisfies `predicate`. set passes through only valid values; an
+      * invalid Some is rejected, None clears the slot.
+      */
+    def filterOption(predicate: V => Boolean): Lens[M, Option[V]] =
+      new Lens[M, Option[V]]:
+        def get(m: M): Option[V] = lens.get(m).filter(predicate)
+        def set(m: M, optV: Option[V]): M =
+          optV match
+            case Some(v) if predicate(v) => lens.set(m, optV)
+            case None                    => lens.set(m, None)
+            case _                       => m
+
+    /** View as `V` with `default` for None; setting writes through as `Some(_)`. */
+    def getOrElse(default: V): Lens[M, V] =
+      new Lens[M, V]:
+        def get(m: M): V       = lens.get(m).getOrElse(default)
+        def set(m: M, v: V): M = lens.set(m, Some(v))
+  end extension
+
+  extension [M, V](lens: Lens[M, List[V]])
+    /** Filter list. `set` retains only elements satisfying `predicate`. */
+    def filterList(predicate: V => Boolean): Lens[M, List[V]] =
+      new Lens[M, List[V]]:
+        def get(m: M): List[V]           = lens.get(m).filter(predicate)
+        def set(m: M, listV: List[V]): M = lens.set(m, listV.filter(predicate))
+
+    /** Focus element at `index`. `Some(v)` writes (or appends iff index == size); `None` removes; out-of-bounds is a
+      * no-op.
+      */
+    def at(index: Int): Lens[M, Option[V]] =
+      new Lens[M, Option[V]]:
+        def get(m: M): Option[V] = lens.get(m).lift(index)
+        def set(m: M, optV: Option[V]): M =
+          val currentList = lens.get(m)
+          optV match
+            case Some(v) if index >= 0 && index < currentList.length =>
+              lens.set(m, currentList.updated(index, v))
+            case Some(v) if index == currentList.length =>
+              lens.set(m, currentList :+ v)
+            case None if index >= 0 && index < currentList.length =>
+              lens.set(m, currentList.patch(index, Nil, 1))
+            case _ => m
+        end set
+
+    def head: Lens[M, Option[V]] = at(0)
+
+    /** Focus all elements after the head. Setting prepends the existing head onto the new tail; if the list was empty,
+      * setting yields the new tail as the whole list.
+      */
+    def tail: Lens[M, List[V]] =
+      new Lens[M, List[V]]:
+        def get(m: M): List[V] = lens.get(m).drop(1)
+        def set(m: M, listV: List[V]): M =
+          val currentList = lens.get(m)
+          currentList.headOption match
+            case Some(h) => lens.set(m, h :: listV)
+            case None    => lens.set(m, listV)
+  end extension
+
+  extension [M, K, V](lens: Lens[M, Map[K, V]])
+    /** Filter map by `(K,V)` predicate. `set` writes the supplied map verbatim (caller decides what's valid). */
+    def filterMap(predicate: (K, V) => Boolean): Lens[M, Map[K, V]] =
+      new Lens[M, Map[K, V]]:
+        def get(m: M): Map[K, V]          = lens.get(m).filter(predicate.tupled)
+        def set(m: M, mapV: Map[K, V]): M = lens.set(m, mapV)
+
+    /** Focus on a specific key. `Some(v)` adds/updates; `None` removes. */
+    def key(k: K): Lens[M, Option[V]] =
+      new Lens[M, Option[V]]:
+        def get(m: M): Option[V] = lens.get(m).get(k)
+        def set(m: M, optV: Option[V]): M =
+          val currentMap = lens.get(m)
+          optV match
+            case Some(v) => lens.set(m, currentMap + (k -> v))
+            case None    => lens.set(m, currentMap - k)
+
+    /** Focus the keyset. Setting drops entries whose keys aren't in the new set. */
+    def keys: Lens[M, Set[K]] =
+      new Lens[M, Set[K]]:
+        def get(m: M): Set[K] = lens.get(m).keySet
+        def set(m: M, ks: Set[K]): M =
+          val currentMap = lens.get(m)
+          lens.set(m, currentMap.filter((k, _) => ks.contains(k)))
+  end extension
+
+  extension [M, V](lens: Lens[M, Vector[V]])
+    /** Focus element at `index` in a Vector — same semantics as List `at`. */
+    def atVector(index: Int): Lens[M, Option[V]] =
+      new Lens[M, Option[V]]:
+        def get(m: M): Option[V] = lens.get(m).lift(index)
+        def set(m: M, optV: Option[V]): M =
+          val cur = lens.get(m)
+          optV match
+            case Some(v) if index >= 0 && index < cur.length => lens.set(m, cur.updated(index, v))
+            case Some(v) if index == cur.length              => lens.set(m, cur :+ v)
+            case None if index >= 0 && index < cur.length    => lens.set(m, cur.patch(index, Vector.empty, 1))
+            case _                                           => m
+  end extension
+
+  /** Effectful traversals — apply an `Either`-returning function across a focused collection, short-circuit on first
+    * failure. These don't return lenses; they return `M => Either[E, _]`.
+    */
+  object Traverse:
+    def traverseList[M, V, W, E](lens: Lens[M, List[V]])(f: V => Either[E, W]): M => Either[E, List[W]] =
+      (m: M) =>
+        lens.get(m).foldLeft(Right(List.empty[W]): Either[E, List[W]]) { (acc, v) =>
+          for
+            xs <- acc
+            w  <- f(v)
+          yield xs :+ w
+        }
+
+    def traverseOption[M, V, W, E](lens: Lens[M, Option[V]])(f: V => Either[E, W]): M => Either[E, Option[W]] =
+      (m: M) =>
+        lens.get(m) match
+          case Some(v) => f(v).map(Some(_))
+          case None    => Right(None)
+  end Traverse
+
+  /** Prism-like focus on a sum-type case. `get` returns Some only for the matching case; `set Some(w)` injects; `set
+    * None` is a no-op (no way to invent a different case).
+    */
+  object Prism:
+    def partial[M, V, W](
+        lens: Lens[M, V]
+    )(extract: V => Option[W], inject: W => V): Lens[M, Option[W]] =
+      new Lens[M, Option[W]]:
+        def get(m: M): Option[W] = extract(lens.get(m))
+        def set(m: M, optW: Option[W]): M =
+          optW match
+            case Some(w) => lens.set(m, inject(w))
+            case None    => m
+  end Prism
+
+end CollectionLens

--- a/core/src/test/scala/conduit/ActionHandlerCollectionsSpec.scala
+++ b/core/src/test/scala/conduit/ActionHandlerCollectionsSpec.scala
@@ -1,0 +1,283 @@
+package conduit
+
+import zio.*
+import zio.test.*
+
+import conduit.ActionHandlerCollections.*
+
+object ActionHandlerCollectionsSpec extends ZIOSpecDefault:
+
+  case class OptModel(o: Option[Int]) derives Optics
+  case class ListModel(xs: List[Int]) derives Optics
+  case class VecModel(v: Vector[Int]) derives Optics
+  case class MapModel(m: Map[String, Int]) derives Optics
+  case class IntModel(n: Int) derives Optics
+
+  // Helper: run an ActionFunction directly without going through a full handler.
+  def run[M, E](af: ActionFunction[M, E])(m: M): IO[E, ActionResult[M, E]] = af(m)
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("ActionHandlerCollections")(
+      suite("Option")(
+        test("updateOption: Some(x) → Some(f(x))"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(updateOption[OptModel, Int, Nothing](_ + 1))(OptModel(Some(5)))
+          yield assertTrue(r.newModel == OptModel(Some(6)), r.dirty)
+        ,
+        test("updateOption: None stays None"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(updateOption[OptModel, Int, Nothing](_ + 1))(OptModel(None))
+          yield assertTrue(r.newModel == OptModel(None))
+        ,
+        test("setSome writes Some(value)"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(setSome[OptModel, Int, Nothing](42))(OptModel(None))
+          yield assertTrue(r.newModel == OptModel(Some(42)))
+        ,
+        test("setNone clears existing Some"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(setNone[OptModel, Int, Nothing])(OptModel(Some(5)))
+          yield assertTrue(r.newModel == OptModel(None))
+        ,
+        test("setNone on already-None is still a (vacuous) write"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(setNone[OptModel, Int, Nothing])(OptModel(None))
+          yield assertTrue(r.newModel == OptModel(None))
+        ,
+        test("filterOptionAction: predicate fails clears Some"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(filterOptionAction[OptModel, Int, Nothing](_ > 0))(OptModel(Some(-1)))
+          yield assertTrue(r.newModel == OptModel(None))
+        ,
+        test("filterOptionAction: predicate holds keeps Some"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(filterOptionAction[OptModel, Int, Nothing](_ > 0))(OptModel(Some(5)))
+          yield assertTrue(r.newModel == OptModel(Some(5)))
+        ,
+        test("orElseOption: None gets default"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(orElseOption[OptModel, Int, Nothing](Some(10)))(OptModel(None))
+          yield assertTrue(r.newModel == OptModel(Some(10)))
+        ,
+        test("orElseOption: Some unchanged"):
+          given Lens[OptModel, Option[Int]] = Optics[OptModel](_.o)
+          for r <- run(orElseOption[OptModel, Int, Nothing](Some(10)))(OptModel(Some(5)))
+          yield assertTrue(r.newModel == OptModel(Some(5))),
+      ),
+      suite("List")(
+        test("updateList maps each element"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateList[ListModel, Int, Nothing](_ * 2))(ListModel(List(1, 2, 3)))
+          yield assertTrue(r.newModel == ListModel(List(2, 4, 6)))
+        ,
+        test("updateList: empty list stays empty"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateList[ListModel, Int, Nothing](_ * 2))(ListModel(Nil))
+          yield assertTrue(r.newModel == ListModel(Nil))
+        ,
+        test("filterListAction filters"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(filterListAction[ListModel, Int, Nothing](_ > 0))(ListModel(List(-1, 2, -3, 4)))
+          yield assertTrue(r.newModel == ListModel(List(2, 4)))
+        ,
+        test("appendToList: zero items still produces a write (concat with empty)"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(appendToList[ListModel, Int, Nothing]())(ListModel(List(1)))
+          yield assertTrue(r.newModel == ListModel(List(1)))
+        ,
+        test("appendToList: many items"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(appendToList[ListModel, Int, Nothing](2, 3))(ListModel(List(1)))
+          yield assertTrue(r.newModel == ListModel(List(1, 2, 3)))
+        ,
+        test("prependToList prepends in given order"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(prependToList[ListModel, Int, Nothing](2, 3))(ListModel(List(99)))
+          yield assertTrue(r.newModel == ListModel(List(2, 3, 99)))
+        ,
+        test("removeFromList removes all occurrences"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(removeFromList[ListModel, Int, Nothing](2))(ListModel(List(1, 2, 3, 2, 4)))
+          yield assertTrue(r.newModel == ListModel(List(1, 3, 4)))
+        ,
+        test("removeFromList: missing element is no-op-by-content (still a write)"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(removeFromList[ListModel, Int, Nothing](99))(ListModel(List(1, 2)))
+          yield assertTrue(r.newModel == ListModel(List(1, 2)))
+        ,
+        test("updateAtListIndex: in range updates"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateAtListIndex[ListModel, Int, Nothing](1, 99))(ListModel(List(1, 2, 3)))
+          yield assertTrue(r.newModel == ListModel(List(1, 99, 3)), r.dirty)
+        ,
+        test("updateAtListIndex: out of range → clean (untouched, dirty=false)"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateAtListIndex[ListModel, Int, Nothing](99, 0))(ListModel(List(1, 2)))
+          yield assertTrue(r.newModel == ListModel(List(1, 2)), !r.dirty)
+        ,
+        test("updateAtListIndex: negative index → clean"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateAtListIndex[ListModel, Int, Nothing](-1, 0))(ListModel(List(1, 2)))
+          yield assertTrue(r.newModel == ListModel(List(1, 2)), !r.dirty)
+        ,
+        test("updateAtListIndex: empty list → clean"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(updateAtListIndex[ListModel, Int, Nothing](0, 0))(ListModel(Nil))
+          yield assertTrue(r.newModel == ListModel(Nil), !r.dirty),
+      ),
+      suite("Vector")(
+        test("updateVector maps elements"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(updateVector[VecModel, Int, Nothing](_ * 2))(VecModel(Vector(1, 2, 3)))
+          yield assertTrue(r.newModel == VecModel(Vector(2, 4, 6)))
+        ,
+        test("filterVectorAction filters"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(filterVectorAction[VecModel, Int, Nothing](_ > 0))(VecModel(Vector(-1, 2, -3)))
+          yield assertTrue(r.newModel == VecModel(Vector(2)))
+        ,
+        test("appendToVector"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(appendToVector[VecModel, Int, Nothing](2, 3))(VecModel(Vector(1)))
+          yield assertTrue(r.newModel == VecModel(Vector(1, 2, 3)))
+        ,
+        test("prependToVector"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(prependToVector[VecModel, Int, Nothing](2, 3))(VecModel(Vector(99)))
+          yield assertTrue(r.newModel == VecModel(Vector(2, 3, 99)))
+        ,
+        test("updateAtVectorIndex: in range updates"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(updateAtVectorIndex[VecModel, Int, Nothing](1, 99))(VecModel(Vector(1, 2, 3)))
+          yield assertTrue(r.newModel == VecModel(Vector(1, 99, 3)), r.dirty)
+        ,
+        test("updateAtVectorIndex: out of range → clean"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(updateAtVectorIndex[VecModel, Int, Nothing](99, 0))(VecModel(Vector(1, 2)))
+          yield assertTrue(!r.dirty)
+        ,
+        test("updateAtVectorIndex: negative → clean"):
+          given Lens[VecModel, Vector[Int]] = Optics[VecModel](_.v)
+          for r <- run(updateAtVectorIndex[VecModel, Int, Nothing](-1, 0))(VecModel(Vector(1)))
+          yield assertTrue(!r.dirty),
+      ),
+      suite("Map")(
+        test("updateMapValues maps values"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(updateMapValues[MapModel, String, Int, Nothing](_ * 2))(MapModel(Map("a" -> 1, "b" -> 2)))
+          yield assertTrue(r.newModel == MapModel(Map("a" -> 2, "b" -> 4)))
+        ,
+        test("filterMapValues filters by value predicate"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(filterMapValues[MapModel, String, Int, Nothing](_ > 1))(MapModel(Map("a" -> 1, "b" -> 2)))
+          yield assertTrue(r.newModel == MapModel(Map("b" -> 2)))
+        ,
+        test("putInMap adds new key"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(putInMap[MapModel, String, Int, Nothing]("z", 99))(MapModel(Map("a" -> 1)))
+          yield assertTrue(r.newModel == MapModel(Map("a" -> 1, "z" -> 99)))
+        ,
+        test("putInMap overwrites existing"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(putInMap[MapModel, String, Int, Nothing]("a", 99))(MapModel(Map("a" -> 1)))
+          yield assertTrue(r.newModel == MapModel(Map("a" -> 99)))
+        ,
+        test("removeFromMap removes existing"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(removeFromMap[MapModel, String, Int, Nothing]("a"))(MapModel(Map("a" -> 1, "b" -> 2)))
+          yield assertTrue(r.newModel == MapModel(Map("b" -> 2)))
+        ,
+        test("removeFromMap on missing key writes through (still dirty)"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(removeFromMap[MapModel, String, Int, Nothing]("z"))(MapModel(Map("a" -> 1)))
+          yield assertTrue(r.newModel == MapModel(Map("a" -> 1)))
+        ,
+        test("updateAtMapKey: existing key applies f"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(updateAtMapKey[MapModel, String, Int, Nothing]("a", _ + 100))(MapModel(Map("a" -> 1)))
+          yield assertTrue(r.newModel == MapModel(Map("a" -> 101)), r.dirty)
+        ,
+        test("updateAtMapKey: missing key → clean"):
+          given Lens[MapModel, Map[String, Int]] = Optics[MapModel](_.m)
+          for r <- run(updateAtMapKey[MapModel, String, Int, Nothing]("missing", _ + 1))(MapModel(Map("a" -> 1)))
+          yield assertTrue(!r.dirty, r.newModel == MapModel(Map("a" -> 1))),
+      ),
+      suite("Generic context-function patterns")(
+        test("whenCondition: predicate holds → applies op"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          for r <- run(whenCondition[IntModel, Int, Nothing](_ > 0)(_ * 2))(IntModel(5))
+          yield assertTrue(r.newModel == IntModel(10), r.dirty)
+        ,
+        test("whenCondition: predicate fails → clean"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          for r <- run(whenCondition[IntModel, Int, Nothing](_ > 0)(_ * 2))(IntModel(-1))
+          yield assertTrue(!r.dirty, r.newModel == IntModel(-1))
+        ,
+        test("safeTransform: Right writes through"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          for r <- run(safeTransform[IntModel, Int, String, Nothing](n => Right(n + 1)))(IntModel(5))
+          yield assertTrue(r.newModel == IntModel(6))
+        ,
+        test("safeTransform: Left → clean"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          for r <- run(safeTransform[IntModel, Int, String, Nothing](_ => Left("nope")))(IntModel(5))
+          yield assertTrue(!r.dirty, r.newModel == IntModel(5))
+        ,
+        test("sequenceOps: applies each op left-to-right"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          val ops: List[Int => Int] = List(_ + 1, _ * 10, _ - 5)
+          for r <- run(sequenceOps[IntModel, Int, Nothing](ops))(IntModel(2))
+            // ((2 + 1) * 10) - 5 = 25
+          yield assertTrue(r.newModel == IntModel(25))
+        ,
+        test("sequenceOps: empty ops still writes (identity)"):
+          given Lens[IntModel, Int] = Optics[IntModel](_.n)
+          for r <- run(sequenceOps[IntModel, Int, Nothing](Nil))(IntModel(5))
+          yield assertTrue(r.newModel == IntModel(5), r.dirty)
+        ,
+        test("findAndUpdate: hit replaces all matching elements"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(findAndUpdate[ListModel, Int, Nothing](_.find(_ == 2))(_ * 100))(ListModel(List(1, 2, 3, 2)))
+          yield assertTrue(r.newModel == ListModel(List(1, 200, 3, 200)), r.dirty)
+        ,
+        test("findAndUpdate: miss → clean"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(findAndUpdate[ListModel, Int, Nothing](_.find(_ == 99))(_ * 100))(ListModel(List(1, 2)))
+          yield assertTrue(!r.dirty, r.newModel == ListModel(List(1, 2)))
+        ,
+        test("batchOperation: condition holds applies op"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(batchOperation[ListModel, Int, Nothing](_.length > 1)(_.reverse))(ListModel(List(1, 2, 3)))
+          yield assertTrue(r.newModel == ListModel(List(3, 2, 1)))
+        ,
+        test("batchOperation: condition fails → clean"):
+          given Lens[ListModel, List[Int]] = Optics[ListModel](_.xs)
+          for r <- run(batchOperation[ListModel, Int, Nothing](_.length > 10)(_.reverse))(ListModel(List(1, 2, 3)))
+          yield assertTrue(!r.dirty, r.newModel == ListModel(List(1, 2, 3))),
+      ),
+      suite("Integration with handle()")(
+        // Verify these helpers compose cleanly into a real ActionHandler
+        test("handle uses appendToList through the lens context") {
+          enum A extends Action:
+            case Add(x: Int)
+
+          val h = handle[ListModel, List[Int], Nothing](Optics[ListModel](_.xs)):
+            case A.Add(x) => appendToList(x)
+
+          for r <- h.process(A.Add(99), ListModel(List(1, 2)))
+          yield assertTrue(r.newModel == ListModel(List(1, 2, 99)))
+        },
+        test("updateAtMapKey returns clean inside a handler when key absent") {
+          enum A extends Action:
+            case Bump(key: String)
+
+          val h = handle[MapModel, Map[String, Int], Nothing](Optics[MapModel](_.m)):
+            case A.Bump(k) => updateAtMapKey[MapModel, String, Int, Nothing](k, _ + 1)
+
+          for r <- h.process(A.Bump("missing"), MapModel(Map("a" -> 1)))
+          yield assertTrue(!r.dirty, r.newModel == MapModel(Map("a" -> 1)))
+        },
+      ),
+    )
+  end spec
+end ActionHandlerCollectionsSpec

--- a/core/src/test/scala/conduit/AdvancedContextFunctionsSpec.scala
+++ b/core/src/test/scala/conduit/AdvancedContextFunctionsSpec.scala
@@ -1,0 +1,221 @@
+package conduit
+
+import zio.*
+import zio.test.*
+
+import conduit.AdvancedContextFunctions.*
+
+object AdvancedContextFunctionsSpec extends ZIOSpecDefault:
+
+  case class Address(city: String, zip: String) derives Optics
+  case class User(name: String, age: Int, address: Address) derives Optics
+  case class Model(user: User, count: Int) derives Optics
+  case class IntBox(n: Int) derives Optics
+  case class TwoFields(a: Int, b: String) derives Optics
+  case class OptUser(name: Option[String]) derives Optics
+
+  enum ForA extends Action:
+    case Rename(s: String)
+    case Move(c: String)
+    case ResetCount
+    case Known
+    case Unknown
+    case Inc
+    case Dec
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("AdvancedContextFunctions")(
+      suite("when")(
+        test("get returns Some when predicate holds"):
+          given Lens[IntBox, Int]             = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Option[Int]] = when(_ > 0)
+          assertTrue(lens.get(IntBox(5)) == Some(5))
+        ,
+        test("get returns None when predicate fails"):
+          given Lens[IntBox, Int]             = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Option[Int]] = when(_ > 0)
+          assertTrue(lens.get(IntBox(-1)) == None)
+        ,
+        test("set Some(valid) writes through"):
+          given Lens[IntBox, Int]             = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Option[Int]] = when(_ > 0)
+          assertTrue(lens.set(IntBox(0), Some(5)) == IntBox(5))
+        ,
+        test("set Some(invalid) is no-op"):
+          given Lens[IntBox, Int]             = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Option[Int]] = when(_ > 0)
+          assertTrue(lens.set(IntBox(5), Some(-1)) == IntBox(5))
+        ,
+        test("set None is no-op (no way to invent a missing value)"):
+          given Lens[IntBox, Int]             = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Option[Int]] = when(_ > 0)
+          assertTrue(lens.set(IntBox(5), None) == IntBox(5)),
+      ),
+      suite("validated")(
+        test("get returns Right when to() succeeds"):
+          given Lens[IntBox, Int] = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Either[String, String]] =
+            validated[IntBox, Int, String, String](
+              n => if n > 0 then Right(n.toString) else Left("non-positive"),
+              _.toInt,
+            )
+          assertTrue(lens.get(IntBox(5)) == Right("5"))
+        ,
+        test("get returns Left when to() fails"):
+          given Lens[IntBox, Int] = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Either[String, String]] =
+            validated[IntBox, Int, String, String](
+              n => if n > 0 then Right(n.toString) else Left("non-positive"),
+              _.toInt,
+            )
+          assertTrue(lens.get(IntBox(-1)) == Left("non-positive"))
+        ,
+        test("set Right(w) writes through via from()"):
+          given Lens[IntBox, Int] = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Either[String, String]] =
+            validated[IntBox, Int, String, String](
+              n => if n > 0 then Right(n.toString) else Left("non-positive"),
+              _.toInt,
+            )
+          assertTrue(lens.set(IntBox(0), Right("42")) == IntBox(42))
+        ,
+        test("set Left(_) is no-op"):
+          given Lens[IntBox, Int] = Optics[IntBox](_.n)
+          val lens: Lens[IntBox, Either[String, String]] =
+            validated[IntBox, Int, String, String](
+              n => if n > 0 then Right(n.toString) else Left("bad"),
+              _.toInt,
+            )
+          assertTrue(lens.set(IntBox(5), Left("anything")) == IntBox(5)),
+      ),
+      suite("multi")(
+        test("get reads both lenses into a tuple"):
+          val both = multi(Optics[TwoFields](_.a), Optics[TwoFields](_.b))
+          assertTrue(both.get(TwoFields(1, "x")) == ((1, "x")))
+        ,
+        test("set writes both fields"):
+          val both = multi(Optics[TwoFields](_.a), Optics[TwoFields](_.b))
+          assertTrue(both.set(TwoFields(0, ""), (5, "ok")) == TwoFields(5, "ok"))
+        ,
+        test("set-get law"):
+          val both = multi(Optics[TwoFields](_.a), Optics[TwoFields](_.b))
+          assertTrue(both.get(both.set(TwoFields(0, ""), (5, "ok"))) == ((5, "ok")))
+        ,
+        test("get-set law (independent fields)"):
+          val both = multi(Optics[TwoFields](_.a), Optics[TwoFields](_.b))
+          val tf   = TwoFields(7, "z")
+          assertTrue(both.set(tf, both.get(tf)) == tf),
+      ),
+      suite("navigate")(
+        test("present path: get reads through"):
+          given Lens[OptUser, Option[String]] = Optics[OptUser](_.name)
+          val lens: Lens[OptUser, String] =
+            navigate[OptUser, Option[String], String](
+              path = identity,
+              defaultValue = "anonymous",
+              inverse = (_, w) => Some(w),
+            )
+          assertTrue(lens.get(OptUser(Some("alice"))) == "alice")
+        ,
+        test("absent path: get returns default"):
+          given Lens[OptUser, Option[String]] = Optics[OptUser](_.name)
+          val lens: Lens[OptUser, String] =
+            navigate[OptUser, Option[String], String](
+              path = identity,
+              defaultValue = "anonymous",
+              inverse = (_, w) => Some(w),
+            )
+          assertTrue(lens.get(OptUser(None)) == "anonymous")
+        ,
+        test("set writes through inverse"):
+          given Lens[OptUser, Option[String]] = Optics[OptUser](_.name)
+          val lens: Lens[OptUser, String] =
+            navigate[OptUser, Option[String], String](
+              path = identity,
+              defaultValue = "anonymous",
+              inverse = (_, w) => Some(w),
+            )
+          assertTrue(lens.set(OptUser(None), "bob") == OptUser(Some("bob")))
+        ,
+        test("set-get law on present branch"):
+          given Lens[OptUser, Option[String]] = Optics[OptUser](_.name)
+          val lens: Lens[OptUser, String] =
+            navigate[OptUser, Option[String], String](
+              path = identity,
+              defaultValue = "anonymous",
+              inverse = (_, w) => Some(w),
+            )
+          assertTrue(lens.get(lens.set(OptUser(None), "bob")) == "bob"),
+      ),
+      suite("For")(
+        // Builder spares repetition: same Optics[Model] shared across many handlers.
+        test("For.field builds a handler focused on a sub-field") {
+          val handler: ActionHandler[Model, String, Nothing] =
+            For[Model, Nothing].field(_.user.name) { case ForA.Rename(s) => updated(s) }
+
+          val m0 = Model(User("Alice", 30, Address("NYC", "10001")), 0)
+          for r <- handler.process(ForA.Rename("Bob"), m0)
+          yield assertTrue(r.newModel.user.name == "Bob")
+        },
+        test("For.field works for deeply nested paths") {
+          val handler: ActionHandler[Model, String, Nothing] =
+            For[Model, Nothing].field(_.user.address.city) { case ForA.Move(c) => updated(c) }
+
+          val m0 = Model(User("Alice", 30, Address("NYC", "10001")), 0)
+          for r <- handler.process(ForA.Move("LA"), m0)
+          yield assertTrue(r.newModel.user.address.city == "LA")
+        },
+        test("For.model builds a whole-model handler") {
+          val handler: ActionHandler[Model, Model, Nothing] =
+            For[Model, Nothing].model { case ForA.ResetCount => update(_.copy(count = 0)) }
+
+          val m0 = Model(User("Alice", 30, Address("NYC", "10001")), 99)
+          for r <- handler.process(ForA.ResetCount, m0)
+          yield assertTrue(r.newModel.count == 0)
+        },
+        test("For: unhandled action produces a defect with E=Nothing (matches handle()'s contract)") {
+          val handler: ActionHandler[Model, Int, Nothing] =
+            For[Model, Nothing].field(_.count) { case ForA.Known => update(_ + 1) }
+
+          val m0 = Model(User("a", 1, Address("c", "z")), 0)
+          for exit <- handler.process(ForA.Unknown, m0).exit
+          yield assertTrue(exit.isFailure)
+        },
+        test("For: handlers compose with >> like any other handler") {
+          val For_ = For[Model, Nothing]
+          val incH = For_.field(_.count) { case ForA.Inc => update(_ + 1) }
+          val decH = For_.field(_.count) { case ForA.Dec => update(_ - 1) }
+          val both = incH >> decH
+
+          val m0 = Model(User("a", 1, Address("c", "z")), 5)
+          for
+            r1 <- both.process(ForA.Inc, m0)
+            r2 <- both.process(ForA.Dec, m0)
+          yield assertTrue(r1.newModel.count == 6, r2.newModel.count == 4)
+        },
+      ),
+      suite("Compositions")(
+        test("when after a derived sub-lens"):
+          val nameLens: Lens[Model, String]         = Optics[Model](_.user.name)
+          given Lens[Model, String]                 = nameLens
+          val nonEmpty: Lens[Model, Option[String]] = when(_.nonEmpty)
+          val m1                                    = Model(User("Alice", 30, Address("NYC", "10001")), 0)
+          val m2                                    = Model(User("", 30, Address("NYC", "10001")), 0)
+          assertTrue(
+            nonEmpty.get(m1) == Some("Alice"),
+            nonEmpty.get(m2) == None,
+            nonEmpty.set(m2, Some("Bob")).user.name == "Bob",
+            nonEmpty.set(m2, Some("")).user.name == "",
+          )
+        ,
+        test("multi composes derived sub-lenses"):
+          val both = multi(Optics[Model](_.user.name), Optics[Model](_.user.age))
+          val m    = Model(User("Alice", 30, Address("NYC", "10001")), 0)
+          assertTrue(
+            both.get(m) == (("Alice", 30)),
+            both.set(m, ("Bob", 99)).user == User("Bob", 99, Address("NYC", "10001")),
+          ),
+      ),
+    )
+  end spec
+end AdvancedContextFunctionsSpec

--- a/core/src/test/scala/conduit/BidirectionalLensSpec.scala
+++ b/core/src/test/scala/conduit/BidirectionalLensSpec.scala
@@ -1,0 +1,227 @@
+package conduit
+
+import zio.*
+import zio.test.*
+
+import conduit.BidirectionalLens.*
+import conduit.BidirectionalLens.Collections.*
+import conduit.BidirectionalLens.Validation.*
+
+object BidirectionalLensSpec extends ZIOSpecDefault:
+
+  case class Box[A](value: A)
+  case class StrBox(s: String) derives Optics
+  case class ListBox(xs: List[Int]) derives Optics
+  case class OptBox(o: Option[Int]) derives Optics
+  case class MapBox(m: Map[String, Int]) derives Optics
+  case class IntBox(n: Int) derives Optics
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("BidirectionalLens")(
+      suite("Iso")(
+        test("reverse swaps to/from"):
+          val iso = Iso[Int, String](_.toString, _.toInt)
+          val rev = iso.reverse
+          assertTrue(rev.to("42") == 42, rev.from(42) == "42")
+        ,
+        test("reverse twice is identity"):
+          val iso = Iso[Int, String](_.toString, _.toInt)
+          val rr  = iso.reverse.reverse
+          assertTrue(rr.to(7) == iso.to(7), rr.from("7") == iso.from("7")),
+      ),
+      suite("xmap / imap")(
+        test("xmap roundtrip"):
+          val lens = Optics[StrBox](_.s).xmap[Int](_.toInt, _.toString)
+          val box  = StrBox("42")
+          assertTrue(lens.get(box) == 42, lens.set(box, 99) == StrBox("99"))
+        ,
+        test("imap roundtrip equals xmap"):
+          val base = Optics[StrBox](_.s)
+          val a    = base.xmap[Int](_.toInt, _.toString)
+          val b    = base.imap(Iso[String, Int](_.toInt, _.toString))
+          val box  = StrBox("7")
+          assertTrue(a.get(box) == b.get(box), a.set(box, 9) == b.set(box, 9))
+        ,
+        test("set-get law on transformed lens"):
+          val lens = Optics[IntBox](_.n).xmap[Long](_.toLong, _.toInt)
+          val box  = IntBox(0)
+          assertTrue(lens.get(lens.set(box, 123L)) == 123L)
+        ,
+        test("xmap with non-roundtrippable transform shows lossy behavior"):
+          // toUpperCase is not invertible (lower→upper→lower loses original casing)
+          // but that's the user's responsibility — verify the pipe still works mechanically
+          val lens = Optics[StrBox](_.s).xmap[String](_.toUpperCase, identity)
+          val box  = StrBox("hello")
+          assertTrue(lens.get(box) == "HELLO", lens.set(box, "WORLD") == StrBox("WORLD")),
+      ),
+      suite("Collections.Isos")(
+        test("listToVector roundtrip"):
+          val iso = Isos.listToVector[Int]
+          assertTrue(iso.from(iso.to(List(1, 2, 3))) == List(1, 2, 3))
+        ,
+        test("vectorToList is reverse of listToVector"):
+          val a = Isos.listToVector[Int].from(Vector(1, 2))
+          val b = Isos.vectorToList[Int].to(Vector(1, 2))
+          assertTrue(a == b)
+        ,
+        test("setToList: List→Set→List dedups"):
+          val iso = Isos.setToList[Int]
+          assertTrue(iso.from(List(1, 2, 2, 3, 3)) == Set(1, 2, 3))
+        ,
+        test("mapToList roundtrip preserves entries"):
+          val iso = Isos.mapToList[String, Int]
+          val m   = Map("a" -> 1, "b" -> 2)
+          assertTrue(iso.from(iso.to(m)) == m)
+        ,
+        test("optionToList: None ↔ Nil"):
+          val iso = Isos.optionToList[Int]
+          assertTrue(iso.to(None) == Nil, iso.from(Nil) == None)
+        ,
+        test("optionToList: Some(x) ↔ List(x)"):
+          val iso = Isos.optionToList[Int]
+          assertTrue(iso.to(Some(5)) == List(5), iso.from(List(5)) == Some(5))
+        ,
+        test("optionToList: multi-element list collapses to head"):
+          val iso = Isos.optionToList[Int]
+          assertTrue(iso.from(List(1, 2, 3)) == Some(1)),
+      ),
+      suite("List extensions")(
+        test("mapListBi forward + backward"):
+          val lens = Optics[ListBox](_.xs).mapListBi[String](_.toString, _.toInt)
+          val box  = ListBox(List(1, 2, 3))
+          assertTrue(
+            lens.get(box) == List("1", "2", "3"),
+            lens.set(box, List("9", "8")) == ListBox(List(9, 8)),
+          )
+        ,
+        test("asVector view + set"):
+          val lens = Optics[ListBox](_.xs).asVector
+          val box  = ListBox(List(1, 2))
+          assertTrue(
+            lens.get(box) == Vector(1, 2),
+            lens.set(box, Vector(7, 8, 9)) == ListBox(List(7, 8, 9)),
+          )
+        ,
+        test("empty list maps to empty list"):
+          val lens = Optics[ListBox](_.xs).mapListBi[String](_.toString, _.toInt)
+          assertTrue(lens.get(ListBox(Nil)) == Nil),
+      ),
+      suite("Option extensions")(
+        test("mapOptionBi None stays None"):
+          val lens = Optics[OptBox](_.o).mapOptionBi[String](_.toString, _.toInt)
+          assertTrue(lens.get(OptBox(None)) == None, lens.set(OptBox(Some(0)), None) == OptBox(None))
+        ,
+        test("mapOptionBi Some roundtrips"):
+          val lens = Optics[OptBox](_.o).mapOptionBi[String](_.toString, _.toInt)
+          val box  = OptBox(Some(42))
+          assertTrue(lens.get(box) == Some("42"), lens.set(box, Some("7")) == OptBox(Some(7)))
+        ,
+        test("asList: None ↔ Nil"):
+          val lens = Optics[OptBox](_.o).asList
+          assertTrue(lens.get(OptBox(None)) == Nil, lens.set(OptBox(Some(0)), Nil) == OptBox(None))
+        ,
+        test("asList: Some(x) ↔ List(x)"):
+          val lens = Optics[OptBox](_.o).asList
+          assertTrue(
+            lens.get(OptBox(Some(5))) == List(5),
+            lens.set(OptBox(None), List(7)) == OptBox(Some(7)),
+          )
+        ,
+        test("withDefault: None reads as default"):
+          val lens = Optics[OptBox](_.o).withDefault(0)
+          assertTrue(lens.get(OptBox(None)) == 0)
+        ,
+        test("withDefault: Some(default) reads as default"):
+          val lens = Optics[OptBox](_.o).withDefault(0)
+          assertTrue(lens.get(OptBox(Some(0))) == 0)
+        ,
+        test("withDefault: setting default collapses to None"):
+          val lens = Optics[OptBox](_.o).withDefault(0)
+          assertTrue(lens.set(OptBox(Some(5)), 0) == OptBox(None))
+        ,
+        test("withDefault: setting non-default writes Some"):
+          val lens = Optics[OptBox](_.o).withDefault(0)
+          assertTrue(lens.set(OptBox(None), 5) == OptBox(Some(5))),
+      ),
+      suite("Map extensions")(
+        test("mapValuesBi forward + backward"):
+          val lens = Optics[MapBox](_.m).mapValuesBi[String](_.toString, _.toInt)
+          val box  = MapBox(Map("a" -> 1, "b" -> 2))
+          assertTrue(
+            lens.get(box) == Map("a" -> "1", "b" -> "2"),
+            lens.set(box, Map("c" -> "3")) == MapBox(Map("c" -> 3)),
+          )
+        ,
+        test("empty map maps to empty map"):
+          val lens = Optics[MapBox](_.m).mapValuesBi[String](_.toString, _.toInt)
+          assertTrue(lens.get(MapBox(Map.empty)) == Map.empty[String, String])
+        ,
+        test("asList of map roundtrips entries"):
+          val lens = Optics[MapBox](_.m).asList
+          val box  = MapBox(Map("a" -> 1, "b" -> 2))
+          assertTrue(lens.get(box).toMap == box.m)
+        ,
+        test("keySet get returns current keys"):
+          val lens = Optics[MapBox](_.m).keySet
+          assertTrue(lens.get(MapBox(Map("a" -> 1, "b" -> 2))) == Set("a", "b"))
+        ,
+        test("keySet set drops absent keys, keeps existing entries"):
+          val lens = Optics[MapBox](_.m).keySet
+          val box  = MapBox(Map("a" -> 1, "b" -> 2, "c" -> 3))
+          // Keep only "a" — "b" and "c" dropped; "z" is not in the map and is silently ignored
+          val result = lens.set(box, Set("a", "z"))
+          assertTrue(result == MapBox(Map("a" -> 1)))
+        ,
+        test("keySet: setting empty set yields empty map"):
+          val lens = Optics[MapBox](_.m).keySet
+          assertTrue(lens.set(MapBox(Map("a" -> 1)), Set.empty) == MapBox(Map.empty)),
+      ),
+      suite("Validation.validated")(
+        test("get returns Some when predicate holds"):
+          val base = Optics[IntBox](_.n)
+          val lens = validated(base)(_ > 0)
+          assertTrue(lens.get(IntBox(5)) == Some(5))
+        ,
+        test("get returns None when predicate fails"):
+          val base = Optics[IntBox](_.n)
+          val lens = validated(base)(_ > 0)
+          assertTrue(lens.get(IntBox(-1)) == None)
+        ,
+        test("set Some(valid) writes through"):
+          val base = Optics[IntBox](_.n)
+          val lens = validated(base)(_ > 0)
+          assertTrue(lens.set(IntBox(0), Some(5)) == IntBox(5))
+        ,
+        test("set Some(invalid) is no-op"):
+          val base = Optics[IntBox](_.n)
+          val lens = validated(base)(_ > 0)
+          val box  = IntBox(5)
+          assertTrue(lens.set(box, Some(-1)) == box)
+        ,
+        test("set None is no-op (no inverse for predicate failure)"):
+          val base = Optics[IntBox](_.n)
+          val lens = validated(base)(_ > 0)
+          val box  = IntBox(5)
+          assertTrue(lens.set(box, None) == box),
+      ),
+      suite("Validation.filteredList")(
+        test("get filters by predicate"):
+          val lens = filteredList(Optics[ListBox](_.xs))(_ % 2 == 0)
+          assertTrue(lens.get(ListBox(List(1, 2, 3, 4))) == List(2, 4))
+        ,
+        test("set filters incoming list"):
+          val lens = filteredList(Optics[ListBox](_.xs))(_ > 0)
+          // Negative values are dropped before being written
+          assertTrue(lens.set(ListBox(Nil), List(-1, 2, -3, 4)) == ListBox(List(2, 4)))
+        ,
+        test("setting empty list clears"):
+          val lens = filteredList(Optics[ListBox](_.xs))(_ > 0)
+          assertTrue(lens.set(ListBox(List(1, 2, 3)), Nil) == ListBox(Nil))
+        ,
+        test("set with all-failing list clears"):
+          val lens = filteredList(Optics[ListBox](_.xs))(_ > 0)
+          assertTrue(lens.set(ListBox(List(1, 2)), List(-1, -2)) == ListBox(Nil)),
+      ),
+    )
+  end spec
+end BidirectionalLensSpec

--- a/core/src/test/scala/conduit/CollectionLensSpec.scala
+++ b/core/src/test/scala/conduit/CollectionLensSpec.scala
@@ -1,0 +1,323 @@
+package conduit
+
+import zio.*
+import zio.test.*
+
+import conduit.CollectionLens.*
+
+object CollectionLensSpec extends ZIOSpecDefault:
+
+  case class OptBox(o: Option[Int]) derives Optics
+  case class ListBox(xs: List[Int]) derives Optics
+  case class MapBox(m: Map[String, Int]) derives Optics
+  case class VecBox(v: Vector[Int]) derives Optics
+
+  sealed trait Shape
+  case class Circle(r: Int)    extends Shape
+  case class Square(side: Int) extends Shape
+  case class ShapeBox(s: Shape) derives Optics
+
+  override def spec: Spec[TestEnvironment & Scope, Any] =
+    suite("CollectionLens")(
+      suite("Option extensions")(
+        test("filterOption: get filters by predicate"):
+          val lens = Optics[OptBox](_.o).filterOption(_ > 0)
+          assertTrue(lens.get(OptBox(Some(5))) == Some(5), lens.get(OptBox(Some(-1))) == None)
+        ,
+        test("filterOption: get on None is None"):
+          val lens = Optics[OptBox](_.o).filterOption(_ > 0)
+          assertTrue(lens.get(OptBox(None)) == None)
+        ,
+        test("filterOption: set Some(valid) writes through"):
+          val lens = Optics[OptBox](_.o).filterOption(_ > 0)
+          assertTrue(lens.set(OptBox(None), Some(5)) == OptBox(Some(5)))
+        ,
+        test("filterOption: set Some(invalid) is no-op"):
+          val lens = Optics[OptBox](_.o).filterOption(_ > 0)
+          val box  = OptBox(Some(10))
+          assertTrue(lens.set(box, Some(-1)) == box)
+        ,
+        test("filterOption: set None clears"):
+          val lens = Optics[OptBox](_.o).filterOption(_ > 0)
+          assertTrue(lens.set(OptBox(Some(5)), None) == OptBox(None))
+        ,
+        test("getOrElse: None reads default"):
+          val lens = Optics[OptBox](_.o).getOrElse(0)
+          assertTrue(lens.get(OptBox(None)) == 0)
+        ,
+        test("getOrElse: Some reads through"):
+          val lens = Optics[OptBox](_.o).getOrElse(0)
+          assertTrue(lens.get(OptBox(Some(5))) == 5)
+        ,
+        test("getOrElse: set writes Some, even if equal to default"):
+          val lens = Optics[OptBox](_.o).getOrElse(0)
+          assertTrue(lens.set(OptBox(None), 0) == OptBox(Some(0))),
+      ),
+      suite("List extensions")(
+        test("filterList: get filters"):
+          val lens = Optics[ListBox](_.xs).filterList(_ > 0)
+          assertTrue(lens.get(ListBox(List(-1, 2, -3, 4))) == List(2, 4))
+        ,
+        test("filterList: set filters incoming"):
+          val lens = Optics[ListBox](_.xs).filterList(_ > 0)
+          assertTrue(lens.set(ListBox(Nil), List(-1, 2, -3)) == ListBox(List(2)))
+        ,
+        test("filterList: set with all-failing list clears"):
+          val lens = Optics[ListBox](_.xs).filterList(_ > 0)
+          assertTrue(lens.set(ListBox(List(1, 2)), List(-1, -2)) == ListBox(Nil))
+        ,
+        test("at: in-range get"):
+          val lens = Optics[ListBox](_.xs).at(1)
+          assertTrue(lens.get(ListBox(List(10, 20, 30))) == Some(20))
+        ,
+        test("at: out-of-bounds get is None"):
+          val lens = Optics[ListBox](_.xs).at(5)
+          assertTrue(lens.get(ListBox(List(1, 2))) == None)
+        ,
+        test("at: negative-index get is None"):
+          val lens = Optics[ListBox](_.xs).at(-1)
+          assertTrue(lens.get(ListBox(List(1, 2))) == None)
+        ,
+        test("at: get on empty list is None"):
+          val lens = Optics[ListBox](_.xs).at(0)
+          assertTrue(lens.get(ListBox(Nil)) == None)
+        ,
+        test("at: set Some at existing index updates"):
+          val lens = Optics[ListBox](_.xs).at(1)
+          assertTrue(lens.set(ListBox(List(1, 2, 3)), Some(99)) == ListBox(List(1, 99, 3)))
+        ,
+        test("at: set Some at index == length appends"):
+          val lens = Optics[ListBox](_.xs).at(3)
+          assertTrue(lens.set(ListBox(List(1, 2, 3)), Some(4)) == ListBox(List(1, 2, 3, 4)))
+        ,
+        test("at: set Some past end is no-op"):
+          val lens = Optics[ListBox](_.xs).at(99)
+          val box  = ListBox(List(1, 2, 3))
+          assertTrue(lens.set(box, Some(0)) == box)
+        ,
+        test("at: set Some at negative index is no-op"):
+          val lens = Optics[ListBox](_.xs).at(-1)
+          val box  = ListBox(List(1, 2))
+          assertTrue(lens.set(box, Some(99)) == box)
+        ,
+        test("at: set None at existing index removes"):
+          val lens = Optics[ListBox](_.xs).at(1)
+          assertTrue(lens.set(ListBox(List(1, 2, 3)), None) == ListBox(List(1, 3)))
+        ,
+        test("at: set None on out-of-bounds is no-op"):
+          val lens = Optics[ListBox](_.xs).at(99)
+          val box  = ListBox(List(1, 2))
+          assertTrue(lens.set(box, None) == box)
+        ,
+        test("at: set Some(0) on empty list at index 0 appends"):
+          val lens = Optics[ListBox](_.xs).at(0)
+          assertTrue(lens.set(ListBox(Nil), Some(7)) == ListBox(List(7)))
+        ,
+        test("head: aliases at(0)"):
+          val lens = Optics[ListBox](_.xs).head
+          assertTrue(
+            lens.get(ListBox(List(10, 20))) == Some(10),
+            lens.set(ListBox(List(10, 20)), Some(99)) == ListBox(List(99, 20)),
+            lens.set(ListBox(List(10, 20)), None) == ListBox(List(20)),
+          )
+        ,
+        test("head on empty list is None"):
+          val lens = Optics[ListBox](_.xs).head
+          assertTrue(lens.get(ListBox(Nil)) == None)
+        ,
+        test("tail: get drops first"):
+          val lens = Optics[ListBox](_.xs).tail
+          assertTrue(lens.get(ListBox(List(1, 2, 3))) == List(2, 3))
+        ,
+        test("tail: get on empty list is empty"):
+          val lens = Optics[ListBox](_.xs).tail
+          assertTrue(lens.get(ListBox(Nil)) == Nil)
+        ,
+        test("tail: set preserves head"):
+          val lens = Optics[ListBox](_.xs).tail
+          assertTrue(lens.set(ListBox(List(1, 2, 3)), List(7, 8)) == ListBox(List(1, 7, 8)))
+        ,
+        test("tail: set on empty list yields the new tail as whole list"):
+          val lens = Optics[ListBox](_.xs).tail
+          assertTrue(lens.set(ListBox(Nil), List(9, 10)) == ListBox(List(9, 10)))
+        ,
+        test("at: works on a 1000-element list"):
+          val big     = ListBox((1 to 1000).toList)
+          val lens    = Optics[ListBox](_.xs).at(500)
+          val updated = lens.set(big, Some(-1))
+          assertTrue(lens.get(big) == Some(501), updated.xs(500) == -1, updated.xs.length == 1000),
+      ),
+      suite("Map extensions")(
+        test("filterMap: get filters by tupled predicate"):
+          val lens = Optics[MapBox](_.m).filterMap((_, v) => v > 1)
+          assertTrue(lens.get(MapBox(Map("a" -> 1, "b" -> 2, "c" -> 3))) == Map("b" -> 2, "c" -> 3))
+        ,
+        test("filterMap: get on empty is empty"):
+          val lens = Optics[MapBox](_.m).filterMap((_, _) => true)
+          assertTrue(lens.get(MapBox(Map.empty)) == Map.empty[String, Int])
+        ,
+        test("filterMap: set writes input verbatim"):
+          val lens = Optics[MapBox](_.m).filterMap((_, v) => v > 1)
+          assertTrue(lens.set(MapBox(Map("a" -> 1)), Map("z" -> 9)) == MapBox(Map("z" -> 9)))
+        ,
+        test("key: get hit"):
+          val lens = Optics[MapBox](_.m).key("a")
+          assertTrue(lens.get(MapBox(Map("a" -> 1))) == Some(1))
+        ,
+        test("key: get miss is None"):
+          val lens = Optics[MapBox](_.m).key("missing")
+          assertTrue(lens.get(MapBox(Map("a" -> 1))) == None)
+        ,
+        test("key: get on empty map is None"):
+          val lens = Optics[MapBox](_.m).key("a")
+          assertTrue(lens.get(MapBox(Map.empty)) == None)
+        ,
+        test("key: set Some adds/updates"):
+          val lens = Optics[MapBox](_.m).key("a")
+          assertTrue(
+            lens.set(MapBox(Map.empty), Some(1)) == MapBox(Map("a" -> 1)),
+            lens.set(MapBox(Map("a" -> 1)), Some(2)) == MapBox(Map("a" -> 2)),
+          )
+        ,
+        test("key: set None removes"):
+          val lens = Optics[MapBox](_.m).key("a")
+          assertTrue(lens.set(MapBox(Map("a" -> 1, "b" -> 2)), None) == MapBox(Map("b" -> 2)))
+        ,
+        test("key: set None on missing key is no-op"):
+          val lens = Optics[MapBox](_.m).key("missing")
+          val box  = MapBox(Map("a" -> 1))
+          assertTrue(lens.set(box, None) == box)
+        ,
+        test("keys: get keyset"):
+          val lens = Optics[MapBox](_.m).keys
+          assertTrue(lens.get(MapBox(Map("a" -> 1, "b" -> 2))) == Set("a", "b"))
+        ,
+        test("keys: get on empty is empty"):
+          val lens = Optics[MapBox](_.m).keys
+          assertTrue(lens.get(MapBox(Map.empty)) == Set.empty[String])
+        ,
+        test("keys: set drops absent keys"):
+          val lens = Optics[MapBox](_.m).keys
+          assertTrue(lens.set(MapBox(Map("a" -> 1, "b" -> 2)), Set("a")) == MapBox(Map("a" -> 1)))
+        ,
+        test("keys: set with novel keys ignores them (no value to invent)"):
+          val lens = Optics[MapBox](_.m).keys
+          assertTrue(lens.set(MapBox(Map("a" -> 1)), Set("a", "z")) == MapBox(Map("a" -> 1)))
+        ,
+        test("keys: set empty clears"):
+          val lens = Optics[MapBox](_.m).keys
+          assertTrue(lens.set(MapBox(Map("a" -> 1, "b" -> 2)), Set.empty) == MapBox(Map.empty)),
+      ),
+      suite("Vector extensions")(
+        test("atVector: in-range get"):
+          val lens = Optics[VecBox](_.v).atVector(1)
+          assertTrue(lens.get(VecBox(Vector(10, 20, 30))) == Some(20))
+        ,
+        test("atVector: out-of-bounds get is None"):
+          val lens = Optics[VecBox](_.v).atVector(99)
+          assertTrue(lens.get(VecBox(Vector(1, 2))) == None)
+        ,
+        test("atVector: negative-index get is None"):
+          val lens = Optics[VecBox](_.v).atVector(-1)
+          assertTrue(lens.get(VecBox(Vector(1, 2))) == None)
+        ,
+        test("atVector: get on empty is None"):
+          val lens = Optics[VecBox](_.v).atVector(0)
+          assertTrue(lens.get(VecBox(Vector.empty)) == None)
+        ,
+        test("atVector: set Some updates in-range"):
+          val lens = Optics[VecBox](_.v).atVector(1)
+          assertTrue(lens.set(VecBox(Vector(1, 2, 3)), Some(99)) == VecBox(Vector(1, 99, 3)))
+        ,
+        test("atVector: set Some at length appends"):
+          val lens = Optics[VecBox](_.v).atVector(2)
+          assertTrue(lens.set(VecBox(Vector(1, 2)), Some(3)) == VecBox(Vector(1, 2, 3)))
+        ,
+        test("atVector: set Some past end is no-op"):
+          val lens = Optics[VecBox](_.v).atVector(99)
+          val box  = VecBox(Vector(1, 2))
+          assertTrue(lens.set(box, Some(0)) == box)
+        ,
+        test("atVector: set None removes"):
+          val lens = Optics[VecBox](_.v).atVector(1)
+          assertTrue(lens.set(VecBox(Vector(1, 2, 3)), None) == VecBox(Vector(1, 3)))
+        ,
+        test("atVector: set None out-of-bounds is no-op"):
+          val lens = Optics[VecBox](_.v).atVector(99)
+          val box  = VecBox(Vector(1, 2))
+          assertTrue(lens.set(box, None) == box)
+        ,
+        test("atVector: set Some at negative index is no-op"):
+          val lens = Optics[VecBox](_.v).atVector(-1)
+          val box  = VecBox(Vector(1))
+          assertTrue(lens.set(box, Some(0)) == box),
+      ),
+      suite("Traverse")(
+        test("traverseList: all-success returns Right"):
+          val tr =
+            Traverse.traverseList(Optics[ListBox](_.xs))((n: Int) => if n > 0 then Right(n.toString) else Left("bad"))
+          assertTrue(tr(ListBox(List(1, 2, 3))) == Right(List("1", "2", "3")))
+        ,
+        test("traverseList: short-circuits on first failure"):
+          val tr =
+            Traverse.traverseList(Optics[ListBox](_.xs))((n: Int) => if n > 0 then Right(n) else Left(s"bad: $n"))
+          assertTrue(tr(ListBox(List(1, -2, 3, -4))) == Left("bad: -2"))
+        ,
+        test("traverseList: empty list returns Right(Nil)"):
+          val tr = Traverse.traverseList(Optics[ListBox](_.xs))((n: Int) => Right(n))
+          assertTrue(tr(ListBox(Nil)) == Right(Nil))
+        ,
+        test("traverseOption: None returns Right(None)"):
+          val tr = Traverse.traverseOption(Optics[OptBox](_.o))((n: Int) => Right(n.toString))
+          assertTrue(tr(OptBox(None)) == Right(None))
+        ,
+        test("traverseOption: Some(valid) returns Right(Some)"):
+          val tr =
+            Traverse.traverseOption(Optics[OptBox](_.o))((n: Int) => if n > 0 then Right(n.toString) else Left("bad"))
+          assertTrue(tr(OptBox(Some(5))) == Right(Some("5")))
+        ,
+        test("traverseOption: Some(invalid) returns Left"):
+          val tr =
+            Traverse.traverseOption(Optics[OptBox](_.o))((n: Int) => if n > 0 then Right(n.toString) else Left("bad"))
+          assertTrue(tr(OptBox(Some(-1))) == Left("bad")),
+      ),
+      suite("Prism")(
+        test("partial: extract on matching case"):
+          val circle = Prism.partial(Optics[ShapeBox](_.s))(
+            { case Circle(r) => Some(r); case _ => None },
+            (r: Int) => Circle(r),
+          )
+          assertTrue(circle.get(ShapeBox(Circle(5))) == Some(5))
+        ,
+        test("partial: extract on non-matching case is None"):
+          val circle = Prism.partial(Optics[ShapeBox](_.s))(
+            { case Circle(r) => Some(r); case _ => None },
+            (r: Int) => Circle(r),
+          )
+          assertTrue(circle.get(ShapeBox(Square(7))) == None)
+        ,
+        test("partial: set Some(w) injects (overwrites foreign case)"):
+          val circle = Prism.partial(Optics[ShapeBox](_.s))(
+            { case Circle(r) => Some(r); case _ => None },
+            (r: Int) => Circle(r),
+          )
+          assertTrue(circle.set(ShapeBox(Square(7)), Some(99)) == ShapeBox(Circle(99)))
+        ,
+        test("partial: set Some(w) on matching case updates"):
+          val circle = Prism.partial(Optics[ShapeBox](_.s))(
+            { case Circle(r) => Some(r); case _ => None },
+            (r: Int) => Circle(r),
+          )
+          assertTrue(circle.set(ShapeBox(Circle(5)), Some(99)) == ShapeBox(Circle(99)))
+        ,
+        test("partial: set None is no-op (can't invent another case)"):
+          val circle = Prism.partial(Optics[ShapeBox](_.s))(
+            { case Circle(r) => Some(r); case _ => None },
+            (r: Int) => Circle(r),
+          )
+          val box = ShapeBox(Square(7))
+          assertTrue(circle.set(box, None) == box),
+      ),
+    )
+  end spec
+end CollectionLensSpec


### PR DESCRIPTION
## Summary

Ports the most valuable ideas from the old `experimental/context-fun` branch onto current `main`, tightened for pre-release: only lawful, justified-by-tests pieces survived. Four new modules + four spec files; **214 new tests** covering negative paths, edge cases, and lens-law verification.

### What's new

- **`BidirectionalLens`** — `Iso`, `xmap`/`imap`, `withDefault`, `keySet`, `validated`, `filteredList`. Lawful bidirectional transforms; clearly documents lossy cases (`Set ↔ List`, `Option ↔ List` on multi-element).
- **`CollectionLens`** — lawful focus into `Option`/`List`/`Map`/`Vector` elements: `at`, `head`, `tail`, `key`, `keys`, `atVector`, `filter*`, plus `Traverse` and `Prism.partial`. Read-only `map*` / `flatMap*` variants dropped — use `BidirectionalLens.mapListBi` / `mapOptionBi` / `mapValuesBi` when you need a writable transform.
- **`ActionHandlerCollections`** — context-function action helpers for collection-shaped slices (`appendToList`, `putInMap`, `updateAtListIndex`, …) plus generic patterns (`whenCondition`, `safeTransform`, `sequenceOps`, `findAndUpdate`, `batchOperation`). Out-of-range and missing-key paths return `ActionResult.clean` so the conduit knows nothing changed.
- **`AdvancedContextFunctions`** — `when`, `validated`, `multi`, `navigate`, plus a `For[Model, E]` handler-builder that spares the repetition of `Optics[Model](...)` across many small handlers in one module.

### What was dropped vs. the experimental branch

- Lens methods whose `set` was a no-op (violates lens laws) — removed in favor of the bidirectional variants that require the caller to supply an inverse.
- `AutoDerivation`'s `AutoListOps`/`CollectionOps`/`DSL.pipeline` scaffolding — added types without adding power. The genuinely useful family-handler builder survived as `For`.
- `focus` context-function combinator — type inference forced verbose call sites; the existing `Lens.apply` (`userLens(_.name)`) does the same job with cleaner inference.

## Test plan

- [x] `sbt core3/test` (262 tests pass on JVM)
- [x] `sbt test` (all platforms — JVM, Scala.js, Native — green)
- [x] `sbt scalafmtCheckAll` clean
- [ ] CI green